### PR TITLE
refactor(web-server): `entity_page` -> `Entity::repos`

### DIFF
--- a/web-server/src/entities.rs
+++ b/web-server/src/entities.rs
@@ -8,7 +8,7 @@ pub(crate) struct Entities {
 }
 
 #[derive(serde::Serialize)]
-struct Entity {
+pub(crate) struct Entity {
     name: String,
 }
 
@@ -33,15 +33,18 @@ pub(crate) async fn entities(args: &Args) -> Json<Entities> {
     Json(Entities { entities })
 }
 
-pub(crate) async fn entity_page(args: &Args, entity_name: &str) -> Json<Repos> {
-    let repo_entry_links = get_entries(&args.data_dir.join(format!("repositories/{entity_name}")))
-        .await
-        .into_iter()
-        .map(|i| Repo {
-            name: i.to_str().unwrap().to_owned(),
+impl Entity {
+    pub(crate) async fn repos(args: &Args, entity_name: &str) -> Json<Repos> {
+        let repo_entry_links =
+            get_entries(&args.data_dir.join(format!("repositories/{entity_name}")))
+                .await
+                .into_iter()
+                .map(|i| Repo {
+                    name: i.to_str().unwrap().to_owned(),
+                })
+                .collect();
+        Json(Repos {
+            repos: repo_entry_links,
         })
-        .collect();
-    Json(Repos {
-        repos: repo_entry_links,
-    })
+    }
 }

--- a/web-server/src/main.rs
+++ b/web-server/src/main.rs
@@ -78,7 +78,7 @@ async fn async_main() {
                 routing::get({
                     let args = args.clone();
                     move |axum::extract::Path(name): axum::extract::Path<String>| async move {
-                        entities::entity_page(&args, &name).await
+                        entities::Entity::repos(&args, &name).await
                     }
                 }),
             )


### PR DESCRIPTION
`entity_page` was a misnomer because it didn't return HTML, since we shifted this crate to being an api server. This fixes the naming to be more sensical.