### PR TITLE
fix(web-frontend): update pages to have proper page titles.

### DIFF
--- a/web-frontend/src/routes/+page.svelte
+++ b/web-frontend/src/routes/+page.svelte
@@ -9,7 +9,7 @@
     });
 </script>
 
-<h1> Repositories: </h1>
+<h1> Entities: </h1>
 <ul>
     {#each $entities as entity (entity.name)}
       <li> <a href = "/{entity.name}"> {entity.name} </a> </li>

--- a/web-frontend/src/routes/[entity]/[repo]/+page.svelte
+++ b/web-frontend/src/routes/[entity]/[repo]/+page.svelte
@@ -10,7 +10,7 @@
     });
 </script>
 
-<h1> Repositories: </h1>
+<h1> Commit Log: </h1>
 <ul>
     {#each $commits as commit (commit.message_header)}
       <h3> {commit.message_header} </h3>


### PR DESCRIPTION
It used to always say `Repositories:` regardless of what page you actually were on. This is fixed now so that it'll always show you where you really are.