### PR TITLE
Commit log pagination

### DIFF
--- a/web-frontend/src/routes/[entity]/[repo]/+page.svelte
+++ b/web-frontend/src/routes/[entity]/[repo]/+page.svelte
@@ -1,22 +1,12 @@
 <script lang="ts">
     import { page } from "$app/stores";
-    import { onMount } from "svelte";
-    import { writable } from "svelte/store";
-    type Commits = {
-        message_header: string,
-        message_body: string,
-        commit_id: string,
-    };
-    const commits = writable([] as Commits[]);
-    onMount(async () =>{
-        let response = await fetch(`http://localhost:4000/api/${$page.url.pathname.substring(1)}/commits`);
-        commits.set((await response.json()).commits);
-    });
+import type { PageData } from "../$types";
+    export let data: PageData;
 </script>
 
 <h1> Commit Log: </h1>
 <ul>
-    {#each $commits as commit (commit.message_header)}
+    {#each data.commits as commit (commit.commit_id)}
       <div class = "commit-log">
           <div class = "commit-header">
               <h3 class="commit-title"> {commit.message_header} </h3>
@@ -29,6 +19,7 @@
       </div>
     {/each}
 </ul>
+<a href="{$page.url.pathname}?rev={data.commits[data.commits.length - 1].commit_id}"> Next </a>
 
 
 <style>

--- a/web-frontend/src/routes/[entity]/[repo]/+page.ts
+++ b/web-frontend/src/routes/[entity]/[repo]/+page.ts
@@ -1,0 +1,21 @@
+import type * as Kit from "@sveltejs/kit";
+import { writable } from "svelte/store";
+
+export type Commits = {
+    message_header: string,
+    message_body: string,
+    commit_id: string,
+};
+
+
+export const load: Kit.Load<{}> = async ({url}): Promise<{ commits: Commits[]; }> => {
+      const request_params = new URLSearchParams({
+      });
+      if(url.searchParams.get("rev")) request_params.append("rev", url.searchParams.get("rev") ?? (() => {throw "Failed to get rev"})());
+
+      let response = await fetch(`http://localhost:4000/api/${url.pathname.substring(1)}/commits?` + request_params);
+
+      let log: { commits: Commits[]} = await response.json();
+      // skip the first since we've already seen it
+      return { commits: log.commits.slice(1) };
+};

--- a/web-server/src/main.rs
+++ b/web-server/src/main.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use axum::{routing, Router, Server};
 use clap::Parser;
 
+use repositories::CommitLogReq;
 use tokio::fs::DirBuilder;
 use tokio_stream::StreamExt;
 
@@ -86,11 +87,9 @@ async fn async_main() {
                 "/api/:entity/:repo/commits",
                 routing::get({
                     let args = args.clone();
-                    move |axum::extract::Path((name, repo)): axum::extract::Path<(
-                        String,
-                        String,
-                    )>| async move {
-                        repositories::CommitLog::commit_log(&args, &name, &repo).await
+                    move |axum::extract::Path((name, repo)): axum::extract::Path<(String, String)>,
+                          axum::extract::Query(req): axum::extract::Query<CommitLogReq>| async move {
+                        repositories::CommitLog::commit_log(&args, &name, &repo, &req).await
                     }
                 }),
             )

--- a/web-server/src/repositories.rs
+++ b/web-server/src/repositories.rs
@@ -1,4 +1,5 @@
 use axum::{http::StatusCode, Json};
+use git2::Oid;
 
 use crate::Args;
 
@@ -14,11 +15,18 @@ struct Commit {
     commit_id: String,
 }
 
+#[derive(serde::Deserialize)]
+pub(crate) struct CommitLogReq {
+    #[serde(default)]
+    rev: Option<String>,
+}
+
 impl CommitLog {
     pub(crate) async fn commit_log(
         args: &Args,
         entity: &str,
         repo_name: &str,
+        req: &CommitLogReq,
     ) -> Result<Json<CommitLog>, StatusCode> {
         let repo = git2::Repository::open_bare(
             args.data_dir
@@ -31,8 +39,18 @@ impl CommitLog {
             }
         })?;
         let mut walk = repo.revwalk().unwrap();
-        walk.push(repo.head().unwrap().peel_to_commit().unwrap().id())
-            .unwrap();
+        match &req.rev {
+            Some(v) => walk
+                .push(
+                    repo.find_commit(Oid::from_str(v).unwrap())
+                        .map_err(|_| StatusCode::NOT_FOUND)?
+                        .id(),
+                )
+                .unwrap(),
+            None => walk
+                .push(repo.head().unwrap().peel_to_commit().unwrap().id())
+                .unwrap(),
+        }
         let messages: Vec<Commit> = walk
             .take(10)
             .map(|oid| {


### PR DESCRIPTION
This PR adds a `rev` query param to `web-server`, and exposes it via a `Next` button in the Commit Log in `web-frontend`. Currently it's not possible to go backwards, as right now the web-server doesn't expose any kind of `revwalk` functionality.