### PR TITLE
feat(ci): run on `push` to `main` or pull_request only.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 on:
   pull_request:
   push:
+    branches:
+      - main
 
 jobs:
   test-rust:


### PR DESCRIPTION
This fixes the entire issue where github actions will run twice on every PR. Once on my local branches, and once because it's also a PR.