### PR TITLE
feat(ci): dependabot updates for `cargo`.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  # Annoyingly enough, doesn't support nix flakes.
+  # Issue: https://github.com/NixOS/nix/issues/9823
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Sadly, dependabot doesn't support nix flakes yet, so that part is not yet implemented. This should atleast get us cargo bumps though.