### PR TITLE
fix(ci): deny clippy warnings.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         uses: DeterminateSystems/magic-nix-cache-action@v2
 
       - name: run clippy
-        run: nix develop --command cargo clippy
+        run: nix develop --command cargo clippy -- -D warnings
 
       - name: run tests
         run: nix develop --command cargo test


### PR DESCRIPTION
They should just not be allowed into the codebase, they can be ignored if need be.