### PR TITLE
fix(ci): `cache` using nix-community typescript clone.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,34 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: install nix
-        uses: cachix/install-nix-action@v22
+      - uses: nixbuild/nix-quick-install-action@v30
+        with:
+          nix_conf: |
+            keep-env-derivations = true
+            keep-outputs = true
 
-      - name: setup cache
-        uses: DeterminateSystems/magic-nix-cache-action@v2
+      - name: Restore and save Nix store
+        uses: nix-community/cache-nix-action@v6
+        with:
+          # restore and save a cache using this key
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          # if there's no cache hit, restore a cache by this prefix
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          # collect garbage until the Nix store size (in bytes) is at most this number
+          # before trying to save a new cache
+          # 1G = 1073741824
+          gc-max-store-size-linux: 1G
+          # do purge caches
+          purge: true
+          # purge all versions of the cache
+          purge-prefixes: nix-${{ runner.os }}-
+          # created more than this number of seconds ago
+          purge-created: 0
+          # or, last accessed more than this number of seconds ago
+          # relative to the start of the `Post Restore and save Nix store` phase
+          purge-last-accessed: 0
+          # except any version with the key that is the same as the `primary-key`
+          purge-primary-key: never
 
       - name: run clippy
         run: nix develop --command cargo clippy -- -D warnings


### PR DESCRIPTION
The old magic-nix-cache stopped working due to API changes from GH. The replacement from determinate systems costs money, so use something else instead.

closes #1 (again)