### PR TITLE
fix(repository.html): break up at `\n` in commit messages using `pre`

### DIFF
--- a/templates/repository.html
+++ b/templates/repository.html
@@ -40,7 +40,7 @@
           </div>
           {% if commit.message_body | trim | length != 0 %}
           <div style="overflow: scroll; border-top: 0;">
-            <code style="white-space-collapse: preserve; white-space: nowrap;"> {{ commit.message_body | trim }} </code>
+            <code style="white-space-collapse: preserve; white-space: pre;"> {{ commit.message_body | trim }} </code>
           </div>
           {% endif %}
         </div>


### PR DESCRIPTION
nowrap was wrong, clearly. It gets rid of *all* new lines.