### PR TITLE
fix(flake.nix): `nix build` works again.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -36,9 +36,9 @@
           defaultCrateOverrides =
             pkgs.defaultCrateOverrides
             // {
-              git2 = attrs: {
+              libgit2-sys = attrs: {
                 nativeBuildInputs = [pkgs.pkg-config];
-                buildInputs = [pkgs.libgit2];
+                buildInputs = [pkgs.libgit2 pkgs.zlib pkgs.libssh2];
               };
             };
         };


### PR DESCRIPTION
todo: get cargo clippy & friends to work through this, for caching purposes. :)